### PR TITLE
Fixed #77

### DIFF
--- a/src/main/java/com/github/wasiqb/coteafs/selenium/core/BrowserPage.java
+++ b/src/main/java/com/github/wasiqb/coteafs/selenium/core/BrowserPage.java
@@ -64,8 +64,7 @@ public class BrowserPage implements IPage <BrowserActions, WebElement, ElementAc
 	 */
 	@Override
 	public ElementAction onElement (final By locator, final WaitStrategy strategy) {
-		// TODO Auto-generated method stub
-		return null;
+		return new ElementAction (onDriver (), locator, strategy);
 	}
 
 	/*
@@ -88,7 +87,6 @@ public class BrowserPage implements IPage <BrowserActions, WebElement, ElementAc
 	 */
 	@Override
 	public ElementAction onElement (final WebElement element, final WaitStrategy strategy) {
-		// TODO Auto-generated method stub
-		return null;
+		return new ElementAction (onDriver (), element, strategy);
 	}
 }

--- a/src/main/java/com/github/wasiqb/coteafs/selenium/core/BrowserPage.java
+++ b/src/main/java/com/github/wasiqb/coteafs/selenium/core/BrowserPage.java
@@ -18,6 +18,7 @@ package com.github.wasiqb.coteafs.selenium.core;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
+import com.github.wasiqb.coteafs.selenium.core.enums.WaitStrategy;
 import com.github.wasiqb.coteafs.selenium.core.page.IPage;
 
 /**
@@ -58,11 +59,36 @@ public class BrowserPage implements IPage <BrowserActions, WebElement, ElementAc
 	/*
 	 * (non-Javadoc)
 	 * @see @see
+	 * com.github.wasiqb.coteafs.selenium.core.page.IPage#onElement(org.openqa.
+	 * selenium.By, com.github.wasiqb.coteafs.selenium.core.enums.WaitStrategy)
+	 */
+	@Override
+	public ElementAction onElement (final By locator, final WaitStrategy strategy) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see @see
 	 * com.github.wasiqb.coteafs.selenium.core.ext.IPage#onElement(org.openqa.
 	 * selenium.WebElement)
 	 */
 	@Override
 	public ElementAction onElement (final WebElement element) {
 		return new ElementAction (onDriver (), element);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see @see
+	 * com.github.wasiqb.coteafs.selenium.core.page.IPage#onElement(org.openqa.
+	 * selenium.WebElement,
+	 * com.github.wasiqb.coteafs.selenium.core.enums.WaitStrategy)
+	 */
+	@Override
+	public ElementAction onElement (final WebElement element, final WaitStrategy strategy) {
+		// TODO Auto-generated method stub
+		return null;
 	}
 }

--- a/src/main/java/com/github/wasiqb/coteafs/selenium/core/ElementAction.java
+++ b/src/main/java/com/github/wasiqb/coteafs/selenium/core/ElementAction.java
@@ -45,8 +45,10 @@ import org.openqa.selenium.support.ui.WebDriverWait;
 
 import com.github.wasiqb.coteafs.selenium.config.ConfigUtil;
 import com.github.wasiqb.coteafs.selenium.config.DelaySetting;
+import com.github.wasiqb.coteafs.selenium.core.element.IElementActions;
 import com.github.wasiqb.coteafs.selenium.core.element.ISelectboxActions;
 import com.github.wasiqb.coteafs.selenium.core.element.ITextboxActions;
+import com.github.wasiqb.coteafs.selenium.core.enums.WaitStrategy;
 import com.google.common.truth.BooleanSubject;
 import com.google.common.truth.StringSubject;
 
@@ -75,6 +77,7 @@ public class ElementAction implements ISelectboxActions, ITextboxActions {
 	private final DelaySetting			delays;
 	private final EventFiringWebDriver	driver;
 	private WebElement					element;
+	private WaitStrategy				strategy;
 	private String						style;
 	private boolean						useBy;
 	private final WebDriverWait			wait;
@@ -92,6 +95,19 @@ public class ElementAction implements ISelectboxActions, ITextboxActions {
 	}
 
 	/**
+	 * @author Wasiq Bhamla
+	 * @since 12-Jul-2019
+	 * @param browserAction
+	 * @param by
+	 * @param strategy
+	 */
+	public ElementAction (final BrowserActions browserAction, final By by,
+		final WaitStrategy strategy) {
+		this (browserAction, by);
+		this.strategy = strategy;
+	}
+
+	/**
 	 * @author wasiqb
 	 * @since Mar 21, 2019 10:16:16 PM
 	 * @param browserAction
@@ -103,6 +119,19 @@ public class ElementAction implements ISelectboxActions, ITextboxActions {
 		this.useBy = false;
 	}
 
+	/**
+	 * @author Wasiq Bhamla
+	 * @since 12-Jul-2019
+	 * @param browserAction
+	 * @param element
+	 * @param strategy
+	 */
+	public ElementAction (final BrowserActions browserAction, final WebElement element,
+		final WaitStrategy strategy) {
+		this (browserAction, element);
+		this.strategy = strategy;
+	}
+
 	private ElementAction (final BrowserActions browserAction) {
 		this.browserAction = browserAction;
 		this.driver = browserAction.driver ();
@@ -112,6 +141,7 @@ public class ElementAction implements ISelectboxActions, ITextboxActions {
 		this.delays = ConfigUtil.appSetting ()
 			.getPlayback ()
 			.getDelays ();
+		this.strategy = WaitStrategy.NONE;
 	}
 
 	/*
@@ -150,24 +180,52 @@ public class ElementAction implements ISelectboxActions, ITextboxActions {
 	/*
 	 * (non-Javadoc)
 	 * @see @see
-	 * com.github.wasiqb.coteafs.selenium.core.ext.ISelectboxActions#deselect(java.
-	 * lang.String)
-	 */
-	@Override
-	public void deselect (final String text) {
-		final Select select = new Select (this.element);
-		select.deselectByValue (text);
-	}
-
-	/*
-	 * (non-Javadoc)
-	 * @see @see
 	 * com.github.wasiqb.coteafs.selenium.core.ext.ISelectboxActions#deselectAll()
 	 */
 	@Override
 	public void deselectAll () {
 		final Select select = new Select (this.element);
 		select.deselectAll ();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see @see com.github.wasiqb.coteafs.selenium.core.element.ISelectboxActions#
+	 * deselectByIndex(int)
+	 */
+	@Override
+	public void deselectByIndex (final int index) {
+		perform (e -> {
+			final Select select = new Select (e);
+			select.deselectByIndex (index);
+		});
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see @see
+	 * com.github.wasiqb.coteafs.selenium.core.ext.ISelectboxActions#deselect(java.
+	 * lang.String)
+	 */
+	@Override
+	public void deselectByText (final String value) {
+		perform (e -> {
+			final Select select = new Select (e);
+			select.deselectByVisibleText (value);
+		});
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see @see com.github.wasiqb.coteafs.selenium.core.element.ISelectboxActions#
+	 * deselectByValue(java.lang.String)
+	 */
+	@Override
+	public void deselectByValue (final String value) {
+		perform (e -> {
+			final Select select = new Select (e);
+			select.deselectByValue (value);
+		});
 	}
 
 	/*
@@ -247,12 +305,41 @@ public class ElementAction implements ISelectboxActions, ITextboxActions {
 
 	/*
 	 * (non-Javadoc)
+	 * @see @see com.github.wasiqb.coteafs.selenium.core.element.ISelectboxActions#
+	 * isMultiSelect()
+	 */
+	@Override
+	public boolean isMultiSelect () {
+		return get (e -> {
+			final Select select = new Select (e);
+			return select.isMultiple ();
+		});
+	}
+
+	/*
+	 * (non-Javadoc)
 	 * @see @see
 	 * com.github.wasiqb.coteafs.selenium.core.ext.IElementActions#isSelected()
 	 */
 	@Override
 	public boolean isSelected () {
 		return get (WebElement::isSelected);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see @see
+	 * com.github.wasiqb.coteafs.selenium.core.element.ISelectboxActions#options()
+	 */
+	@Override
+	public List <IElementActions> options () {
+		return get (e -> {
+			final Select select = new Select (e);
+			return select.getOptions ()
+				.stream ()
+				.map (o -> new ElementAction (this.browserAction, o))
+				.collect (Collectors.toList ());
+		});
 	}
 
 	/*
@@ -268,15 +355,57 @@ public class ElementAction implements ISelectboxActions, ITextboxActions {
 
 	/*
 	 * (non-Javadoc)
+	 * @see @see com.github.wasiqb.coteafs.selenium.core.element.ISelectboxActions#
+	 * selectByIndex(int)
+	 */
+	@Override
+	public void selectByIndex (final int index) {
+		perform (e -> {
+			final Select select = new Select (e);
+			select.selectByIndex (index);
+		});
+	}
+
+	/*
+	 * (non-Javadoc)
 	 * @see @see
 	 * com.github.wasiqb.coteafs.selenium.core.ext.ISelectboxActions#select(java.
 	 * lang.String)
 	 */
 	@Override
-	public void select (final String value) {
+	public void selectByText (final String value) {
 		perform (e -> {
 			final Select select = new Select (e);
 			select.selectByVisibleText (value);
+		});
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see @see com.github.wasiqb.coteafs.selenium.core.element.ISelectboxActions#
+	 * selectByValue(java.lang.String)
+	 */
+	@Override
+	public void selectByValue (final String value) {
+		perform (e -> {
+			final Select select = new Select (e);
+			select.selectByValue (value);
+		});
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see @see com.github.wasiqb.coteafs.selenium.core.element.ISelectboxActions#
+	 * selectedOptions()
+	 */
+	@Override
+	public List <IElementActions> selectedOptions () {
+		return get (e -> {
+			final Select select = new Select (e);
+			return select.getAllSelectedOptions ()
+				.stream ()
+				.map (o -> new ElementAction (this.browserAction, o))
+				.collect (Collectors.toList ());
 		});
 	}
 
@@ -422,7 +551,7 @@ public class ElementAction implements ISelectboxActions, ITextboxActions {
 	}
 
 	private void prepareForAction (final String color) {
-		waitUntilVisible ();
+		waitForStrategy ();
 		highlight (color);
 		pause (this.delays.getHighlight ());
 		unhighlight ();
@@ -433,6 +562,30 @@ public class ElementAction implements ISelectboxActions, ITextboxActions {
 			this.browserAction.execute ("arguments[0].setAttribute('style', arguments[1]);",
 				this.element, this.style);
 			this.alreadyHighlighted = true;
+		}
+	}
+
+	/**
+	 * @author Wasiq Bhamla
+	 * @since 12-Jul-2019
+	 */
+	private void waitForStrategy () {
+		switch (this.strategy) {
+			case CLICKABLE:
+				waitUntilClickable ();
+				break;
+			case VISIBLE:
+				waitUntilVisible ();
+				break;
+			case INVISIBLE:
+				waitUntilInvisible ();
+				break;
+			case NONE:
+			default:
+				if (this.useBy) {
+					this.element = this.driver.findElement (this.by);
+				}
+				break;
 		}
 	}
 

--- a/src/main/java/com/github/wasiqb/coteafs/selenium/core/element/ISelectboxActions.java
+++ b/src/main/java/com/github/wasiqb/coteafs/selenium/core/element/ISelectboxActions.java
@@ -15,6 +15,8 @@
  */
 package com.github.wasiqb.coteafs.selenium.core.element;
 
+import java.util.List;
+
 /**
  * @author Wasiq Bhamla
  * @since 07-Jun-2019
@@ -23,20 +25,69 @@ public interface ISelectboxActions extends IKeyboardActions {
 	/**
 	 * @author Wasiq Bhamla
 	 * @since 07-Jun-2019
-	 * @param text
-	 */
-	void deselect (String text);
-
-	/**
-	 * @author Wasiq Bhamla
-	 * @since 07-Jun-2019
 	 */
 	void deselectAll ();
 
 	/**
 	 * @author Wasiq Bhamla
-	 * @since 07-Jun-2019
-	 * @param text
+	 * @since 12-Jul-2019
+	 * @param index
 	 */
-	void select (String text);
+	void deselectByIndex (int index);
+
+	/**
+	 * @author Wasiq Bhamla
+	 * @since 07-Jun-2019
+	 * @param value
+	 */
+	void deselectByText (String value);
+
+	/**
+	 * @author Wasiq Bhamla
+	 * @since 12-Jul-2019
+	 * @param value
+	 */
+	void deselectByValue (String value);
+
+	/**
+	 * @author Wasiq Bhamla
+	 * @since 12-Jul-2019
+	 * @return is multi select
+	 */
+	boolean isMultiSelect ();
+
+	/**
+	 * @author Wasiq Bhamla
+	 * @since 12-Jul-2019
+	 * @return all options
+	 */
+	List <IElementActions> options ();
+
+	/**
+	 * @author Wasiq Bhamla
+	 * @since 12-Jul-2019
+	 * @param index
+	 */
+	void selectByIndex (int index);
+
+	/**
+	 * @author Wasiq Bhamla
+	 * @since 07-Jun-2019
+	 * @param value
+	 */
+	void selectByText (String value);
+
+	/**
+	 * @author Wasiq Bhamla
+	 * @since 12-Jul-2019
+	 * @param value
+	 */
+	void selectByValue (String value);
+
+	/**
+	 * @author Wasiq Bhamla
+	 * @since 12-Jul-2019
+	 * @return all selected options
+	 */
+	List <IElementActions> selectedOptions ();
 }

--- a/src/main/java/com/github/wasiqb/coteafs/selenium/core/enums/WaitStrategy.java
+++ b/src/main/java/com/github/wasiqb/coteafs/selenium/core/enums/WaitStrategy.java
@@ -29,6 +29,10 @@ public enum WaitStrategy {
 	 */
 	INVISIBLE,
 	/**
+	 * None.
+	 */
+	NONE,
+	/**
 	 * Wait until visible.
 	 */
 	VISIBLE;

--- a/src/main/java/com/github/wasiqb/coteafs/selenium/core/page/IPage.java
+++ b/src/main/java/com/github/wasiqb/coteafs/selenium/core/page/IPage.java
@@ -20,6 +20,7 @@ import org.openqa.selenium.WebElement;
 
 import com.github.wasiqb.coteafs.selenium.core.driver.IDriverActions;
 import com.github.wasiqb.coteafs.selenium.core.element.IElementActions;
+import com.github.wasiqb.coteafs.selenium.core.enums.WaitStrategy;
 
 /**
  * @author Wasiq Bhamla
@@ -46,9 +47,27 @@ public interface IPage <B extends IDriverActions, E extends WebElement, T extend
 
 	/**
 	 * @author Wasiq Bhamla
+	 * @since 12-Jul-2019
+	 * @param locator
+	 * @param strategy
+	 * @return element action
+	 */
+	T onElement (By locator, WaitStrategy strategy);
+
+	/**
+	 * @author Wasiq Bhamla
 	 * @since 08-Jun-2019
 	 * @param element
 	 * @return element action
 	 */
 	T onElement (E element);
+
+	/**
+	 * @author Wasiq Bhamla
+	 * @since 12-Jul-2019
+	 * @param element
+	 * @param strategy
+	 * @return element action
+	 */
+	T onElement (E element, WaitStrategy strategy);
 }

--- a/src/test/java/com/github/wasiqb/coteafs/selenium/pages/action/NewAccountPageAction.java
+++ b/src/test/java/com/github/wasiqb/coteafs/selenium/pages/action/NewAccountPageAction.java
@@ -50,7 +50,7 @@ public class NewAccountPageAction extends AbstractPageAction <NewAccountPageActi
 		acc.customerId ()
 			.enterText (value ("CustomerId"));
 		acc.accountType ()
-			.select (fake.bool ()
+			.selectByText (fake.bool ()
 				.bool () ? "Current" : "Savings");
 		acc.initialDeposit ()
 			.enterText (fake.number ()


### PR DESCRIPTION
- **NEW:** `WaitStrategy` added. Default will be `NONE`.
- **NEW:** New overloaded methods added in BrowserPage to consume `WaitStrategy`.
- **NEW:** New method in `ISelectboxActions` added:
  - `deselectByIndex`
  - `deselectByValue`
  - `isMultiSelect`
  - `options`
  - `selectByIndex`
  - `selectByValue`
  - `selectedOptions`
- **BREAKING:** Old methods in `ISelectboxActions` renamed:
  - `select` -> `selectByText`
  - `deselect` -> `deselectByText`